### PR TITLE
Allow specification of timezones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER SteamCache.Net Team <team@steamcache.net>
 ARG DEBIAN_FRONTEND=noninteractive
 RUN \
   apt-get -y update && apt-get -y upgrade && \
-  apt-get -y install supervisor curl wget bzip2 locales && \
+  apt-get -y install supervisor curl wget bzip2 locales tzdata && \
   locale-gen en_GB.utf8 && \
   update-locale LANG=en_GB.utf8 && \
   mkdir --mode 777 -p /var/log/supervisor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV \
   SUPERVISORD_EXIT_ON_FATAL=1 \
   LC_ALL=en_GB.UTF-8 \
   LANG=en_GB.UTF-8 \
-  LANGUAGE=en_GB.UTF-8 
+  LANGUAGE=en_GB.UTF-8 \
+  TZ=Europe/London
 COPY overlay/ /
 RUN chmod -R 755 /init /hooks
 ENTRYPOINT ["/bin/bash", "-e", "/init/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ If you need to change the timezone that the container uses, it is defined by the
 You can override this by using the `-e` argument to docker run and specifying your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ```
--e TZ="Europe/London"
+-e TZ="Australia/Melbourne"
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,17 @@ This docker image is not designed for use by anyone outside of the steamcache or
 To build just run `docker build --tag steamcache/ubuntu:testing .`.
 To test you can run `./run_tests.sh`
 
+## Changing container timezone
+
+If you need to change the timezone that the container uses, it is defined by the `TZ` environment variable. The default is `Europe/London`.
+
+```
+ TZ=Europe/London
+```
+
+You can override this by using the `-e` argument to docker run and specifying your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+```
+-e TZ="Europe/London"
+```
+


### PR DESCRIPTION
This pull request includes the tzdata package.

This provides the ability to set a timezone within the container by passing in the environment variable `TZ`, for example `TZ=Europe/London`
