### PR TITLE
Switch to pip supervisord

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,13 @@ jobs:
           paths:
             lancachenet-ubuntu.tar
       - store_test_results:
-          path: reports
+          path: reports/goss/report.xml
       - store_artifacts:
           path: reports
           destination: reports
+      - store_artifacts:
+          path: workspace/lancachenet-ubuntu.tar
+          destination: docker-lancachenet-ubuntu.tar
   publish_latest:
     docker:
       - image: circleci/python:2-jessie

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 workflows:
-  version: 2
+  version: 2.1
   build_test_deploy:
     jobs:
       - test
@@ -38,21 +38,21 @@ workflows:
           requires:
             - publish_latest
 
-version: 2
+version: 2.1
+executors:
+  testbuild-executor:
+    machine:
+      image: ubuntu-1604:201903-01
 jobs:
   test:
-    docker:
-      - image: circleci/python:2-jessie
+    executor: testbuild-executor
     steps:
       - checkout
-
-      - setup_remote_docker:   # (2)
-          docker_layer_caching: false # (3)
       - run:
           name: Install goss
           command: |
             # rather than give internet scripts SU rights, we install to local user bin and add to path
-            mkdir ~/bin
+            [ -d ~/bin ] || mkdir ~/bin
             export GOSS_DST=~/bin
             export PATH=$PATH:~/bin
             curl -fsSL https://goss.rocks/install | sh
@@ -62,19 +62,14 @@ jobs:
           command: |
             # Don't forget path!
             export PATH=$PATH:~/bin
-            # Important, change from mount to work on remote docker, see https://github.com/aelsabbahy/goss/pull/271
-            # If using machine image you do not need this.
-            export GOSS_FILES_STRATEGY=cp
-            ./run-tests.sh circleci keepimage
+            ./run-tests.sh --circleci --keepimage
       - run:
           name: Save docker image
           command: |
-            mkdir -p workspace
+            [ -d workspace ] || mkdir workspace
             docker save -o workspace/lancachenet-ubuntu.tar lancachenet/ubuntu:goss-test
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            lancachenet-ubuntu.tar
+            #Download from Artifacts and Load this into your own docker using the following command
+            #docker load -i /tmp/workspace/lancachenet-ubuntu.tar
       - store_test_results:
           path: reports/goss/report.xml
       - store_artifacts:
@@ -84,24 +79,16 @@ jobs:
           path: workspace/lancachenet-ubuntu.tar
           destination: docker-lancachenet-ubuntu.tar
   publish_latest:
-    docker:
-      - image: circleci/python:2-jessie
+    executor: testbuild-executor
     steps:
-      - setup_remote_docker:   # (2)
-          docker_layer_caching: false # (3)
-      - attach_workspace:
-          at: /tmp/workspace
       - run:
           name: "Deploy latest to docker hub"
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            #docker build -t lancachenet/ubuntu:latest .
-            docker load -i /tmp/workspace/lancachenet-ubuntu.tar
             docker tag lancachenet/ubuntu:goss-test lancachenet/ubuntu:latest
             docker push lancachenet/ubuntu:latest
   build_children:
-    docker:
-      - image: circleci/python:2-jessie
+    executor: testbuild-executor
     steps:
       - run:
           name: "Request API to build children"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ MAINTAINER LanCache.Net Team <team@lancache.net>
 ARG DEBIAN_FRONTEND=noninteractive
 RUN \
   apt-get -y update && apt-get -y upgrade && \
-  apt-get -y install python-pip curl wget bzip2 locales tzdata && \
+  apt-get -y install python3-pip curl wget bzip2 locales tzdata && \
   locale-gen en_GB.utf8 && \
   update-locale LANG=en_GB.utf8
 RUN \
-  pip install supervisor && \
+  pip3 install supervisor && \
   mkdir --mode 777 -p /var/log/supervisor
 RUN \
   apt-get -y clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ ENV \
   LC_ALL=en_GB.UTF-8 \
   LANG=en_GB.UTF-8 \
   LANGUAGE=en_GB.UTF-8 \
-  TZ=Europe/London
+  TZ=Europe/London \
+  SUPERVISORD_LOGLEVEL=WARN
 COPY overlay/ /
 RUN chmod -R 755 /init /hooks
 ENTRYPOINT ["/bin/bash", "-e", "/init/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ MAINTAINER LanCache.Net Team <team@lancache.net>
 ARG DEBIAN_FRONTEND=noninteractive
 RUN \
   apt-get -y update && apt-get -y upgrade && \
-  apt-get -y install supervisor curl wget bzip2 locales tzdata && \
+  apt-get -y install python-pip curl wget bzip2 locales tzdata && \
   locale-gen en_GB.utf8 && \
-  update-locale LANG=en_GB.utf8 && \
-  mkdir --mode 777 -p /var/log/supervisor && \
+  update-locale LANG=en_GB.utf8
+RUN \
+  pip install supervisor && \
+  mkdir --mode 777 -p /var/log/supervisor
+RUN \
   apt-get -y clean && \
   rm -rf /var/lib/apt/lists/*
 ENV \

--- a/goss.yaml
+++ b/goss.yaml
@@ -3,7 +3,7 @@ package:
     installed: true
   curl:
     installed: true
-  python-pip:
+  python3-pip:
     installed: true
   wget:
     installed: true

--- a/goss.yaml
+++ b/goss.yaml
@@ -3,7 +3,7 @@ package:
     installed: true
   curl:
     installed: true
-  supervisor:
+  python-pip:
     installed: true
   wget:
     installed: true

--- a/overlay/init/supervisord
+++ b/overlay/init/supervisord
@@ -26,4 +26,4 @@ fi
 [[ -f "/hooks/supervisord-pre" ]] && echo "The /hooks/supervisord-pre hook has been replaced with /hooks/supervisord-pre.d/*" && exit 1
 #[ -f "/hooks/supervisord-pre" ] && /hooks/supervisord-pre
 
-exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf -e ${SUPERVISORD_LOGLEVEL:-error}
+exec /usr/local/bin/supervisord -n -c /etc/supervisor/supervisord.conf -e ${SUPERVISORD_LOGLEVEL:-error}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,15 +9,17 @@ if [ $? -ne 0 ]; then
 fi
 
 docker build --tag lancachenet/ubuntu:goss-test .
+
 case $1 in
   circleci)
-    shift;
-    mkdir -p ./reports/goss
+	shift;
+	mkdir -p ./reports/goss
 	if [[ "$1" == "keepimage" ]]; then
 		KEEPIMAGE=true
 		shift
 	fi
-    export GOSS_OPTS="$GOSS_OPTS --format junit"
+	export GOSS_OPTS="$GOSS_OPTS --format junit"
+	export CONTAINER_LOG_OUTPUT="reports/goss/docker.log"
 	dgoss run $@ lancachenet/ubuntu:goss-test > reports/goss/report.xml
 	#store result for exit code
 	RESULT=$?

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,59 +1,9 @@
 #!/bin/bash
-which goss
 
-if [ $? -ne 0 ]; then
-	echo "Please install goss from https://goss.rocks/install"
-	echo "For a quick auto install run the following"
-	echo "curl -fsSL https://goss.rocks/install | sh"
-	exit $?
+if [[ "$@" == *" -- "* ]]; then
+	SD_LOGLEVEL="-e SUPERVISORD_LOGLEVEL=INFO"
+else
+	SD_LOGLEVEL="-- -e SUPERVISORD_LOGLEVEL=INFO"
 fi
 
-docker build --tag lancachenet/ubuntu:goss-test .
-
-
-case $1 in
-  circleci)
-	shift;
-	mkdir -p ./reports/goss
-	if [[ "$1" == "keepimage" ]]; then
-		KEEPIMAGE=true
-		shift
-	fi
-	export GOSS_OPTS="$GOSS_OPTS --format junit"
-	export CONTAINER_LOG_OUTPUT="reports/goss/docker.log"
-	dgoss run -e SUPERVISORD_LOGLEVEL=INFO $@ lancachenet/ubuntu:goss-test > reports/goss/report.xml
-	echo \
-"Container Output: 
-$(cat reports/goss/docker.log)" \
-	> reports/goss/docker.log
-	#store result for exit code
-	RESULT=$?
-	#delete the junk that goss currently outputs :(
-    sed -i '0,/^</d' reports/goss/report.xml
-	#remove invalid system-err outputs from junit output so circleci can read it
-	sed -i '/<system-err>.*<\/system-err>/d' reports/goss/report.xml
-    ;;
-  *)
-	if [[ "$1" == "keepimage" ]]; then
-		KEEPIMAGE=true
-		shift
-	fi
-	echo $1
-	if [[ "$1" == "showlog" ]]; then
-		echo "Enabling showlog"
-		SHOWLOG=true
-		shift
-		export CONTAINER_LOG_OUTPUT="docker.log"
-	fi
-	dgoss run -e SUPERVISORD_LOGLEVEL=INFO $@ lancachenet/ubuntu:goss-test
-	if [[ "$SHOWLOG" ==  "true" ]]; then
-		echo "Contianer Output:"
-		cat "docker.log"
-		rm "docker.log"
-	fi
-	RESULT=$?
-    ;;
-esac
-[[ "$KEEPIMAGE" == "true" ]] || docker rmi lancachenet/ubuntu:goss-test
-
-exit $RESULT
+curl -fsSL https://raw.githubusercontent.com/lancachenet/test-suite/master/dgoss-tests.sh | bash -s -- --imagename="lancachenet/ubuntu:goss-test" $@ $SD_LOGLEVEL


### PR DESCRIPTION
Some investigation into the `CRIT: Set uid to user 0` message on start up shows that this was reclassified as an info message back in I2018.

Ubuntu baseline supervisord is very out of date, we should use the pip stable version instead

*Edit*
Having accidentally fallen down a rabbit hole I also took the oppourtunity to make some changes to run-tests (which will roll out accross lancache.net after this has been accepted) and circleci

* Centralised dgoss-tests.sh (https://github.com/lancachenet/test-suite)
* Save container image and container output to improve diagnostics and review of PR's
* Move from docker based ci to machine based (required to allow access to the docker logs, we are still building and publishing docker images)