### PR TITLE
Supervisord tidyup

### DIFF
--- a/overlay/hooks/supervisord-ready
+++ b/overlay/hooks/supervisord-ready
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Default empty script - supervisord fails if this doesn't exist.  Override it in child images if required
-
-exit 0

--- a/overlay/init/supervisord
+++ b/overlay/init/supervisord
@@ -26,4 +26,6 @@ fi
 [[ -f "/hooks/supervisord-pre" ]] && echo "The /hooks/supervisord-pre hook has been replaced with /hooks/supervisord-pre.d/*" && exit 1
 #[ -f "/hooks/supervisord-pre" ] && /hooks/supervisord-pre
 
+echo "Starting Supervisord"
+
 exec /usr/local/bin/supervisord -n -c /etc/supervisor/supervisord.conf -e ${SUPERVISORD_LOGLEVEL:-error}


### PR DESCRIPTION
Remove supervisord_ready hook as this is no longer referenced
Added a log message to show that supervisord is starting