### PR TITLE
Add `min_free` support by updating Ubuntu which uses the newest version of NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,29 @@
 FROM ubuntu:24.04
-MAINTAINER LanCache.Net Team <team@lancache.net>
+LABEL maintainer="LanCache.Net Team <team@lancache.net>"
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN \
-  apt-get -y update && apt-get -y upgrade && \
-  apt-get -y install python3-pip curl wget bzip2 locales tzdata --no-install-recommends && \
-  locale-gen en_GB.utf8 && \
-  update-locale LANG=en_GB.utf8 && \
-  apt-get -y clean && \
-  rm -rf /var/lib/apt/lists/*
+    apt-get -y update && apt-get -y upgrade && \
+    apt-get -y install python3-pip curl wget bzip2 locales tzdata --no-install-recommends && \
+    locale-gen en_GB.utf8 && \
+    update-locale LANG=en_GB.utf8 && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN \
-  pip3 install supervisor --break-system-packages && \
-  mkdir --mode 777 -p /var/log/supervisor
+    pip3 install supervisor --break-system-packages && \
+    mkdir --mode 777 -p /var/log/supervisor
 RUN \
-  apt-get -y clean && \
-  rm -rf /var/lib/apt/lists/*
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV \
-  SUPERVISORD_EXIT_ON_FATAL=1 \
-  LC_ALL=en_GB.UTF-8 \
-  LANG=en_GB.UTF-8 \
-  LANGUAGE=en_GB.UTF-8 \
-  TZ=Europe/London \
-  SUPERVISORD_LOGLEVEL=WARN
+    SUPERVISORD_EXIT_ON_FATAL=1 \
+    LC_ALL=en_GB.UTF-8 \
+    LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB.UTF-8 \
+    TZ=Europe/London \
+    SUPERVISORD_LOGLEVEL=WARN
+
 COPY overlay/ /
 RUN chmod -R 755 /init /hooks
 ENTRYPOINT ["/bin/bash", "-e", "/init/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM ubuntu:bionic
+FROM ubuntu:24.04
 MAINTAINER LanCache.Net Team <team@lancache.net>
 ARG DEBIAN_FRONTEND=noninteractive
 RUN \
   apt-get -y update && apt-get -y upgrade && \
-  apt-get -y install python3-pip curl wget bzip2 locales tzdata && \
+  apt-get -y install python3-pip curl wget bzip2 locales tzdata --no-install-recommends && \
   locale-gen en_GB.utf8 && \
-  update-locale LANG=en_GB.utf8
+  update-locale LANG=en_GB.utf8 && \
+  apt-get -y clean && \
+  rm -rf /var/lib/apt/lists/*
 RUN \
-  pip3 install supervisor && \
+  pip3 install supervisor --break-system-packages && \
   mkdir --mode 777 -p /var/log/supervisor
 RUN \
   apt-get -y clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get -y update && apt-get -y upgrade && \
-    apt-get -y install python3-pip curl wget bzip2 locales tzdata --no-install-recommends && \
+    apt-get -y install supervisor curl wget bzip2 locales tzdata --no-install-recommends && \
     locale-gen en_GB.utf8 && \
     update-locale LANG=en_GB.utf8 && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
-RUN \
-    pip3 install supervisor --break-system-packages && \
-    mkdir --mode 777 -p /var/log/supervisor
 
 ENV \
     SUPERVISORD_EXIT_ON_FATAL=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ RUN \
 RUN \
     pip3 install supervisor --break-system-packages && \
     mkdir --mode 777 -p /var/log/supervisor
-RUN \
-    apt-get -y clean && \
-    rm -rf /var/lib/apt/lists/*
 
 ENV \
     SUPERVISORD_EXIT_ON_FATAL=1 \

--- a/goss.yaml
+++ b/goss.yaml
@@ -3,8 +3,6 @@ package:
     installed: true
   curl:
     installed: true
-  python3-pip:
-    installed: true
   wget:
     installed: true
 process:

--- a/overlay/init/supervisord
+++ b/overlay/init/supervisord
@@ -28,4 +28,4 @@ fi
 
 echo "Starting Supervisord"
 
-exec /usr/local/bin/supervisord -n -c /etc/supervisor/supervisord.conf -e ${SUPERVISORD_LOGLEVEL:-error}
+exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf -e ${SUPERVISORD_LOGLEVEL:-error}


### PR DESCRIPTION
See parent issue [lancachenet/monolithic - Implement NGINX 'min_free` parameter to ensure cache drive always has free space](https://github.com/lancachenet/monolithic/issues/190)